### PR TITLE
refactored name and updated groupId

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'org.jetbrains.intellij' version '0.4.16'
 }
 
-group 'Open-Liberty'
+group 'io.openliberty.tools'
 version '0.0.1'
 
 sourceCompatibility = 1.8
@@ -13,7 +13,7 @@ repositories {
 }
 
 dependencies {
-    testCompile group: 'junit', name: 'junit', version: '4.12'
+    testImplementation group: 'junit', name: 'junit', version: '4.12'
 }
 
 runIde {

--- a/src/main/java/io/openliberty/tools/intellij/LibertyActionNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyActionNode.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij;
+package io.openliberty.tools.intellij;
 
 import javax.swing.tree.DefaultMutableTreeNode;
 

--- a/src/main/java/io/openliberty/tools/intellij/LibertyDevToolWindowFactory.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyDevToolWindowFactory.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij;
+package io.openliberty.tools.intellij;
 
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.wm.ToolWindow;

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij;
+package io.openliberty.tools.intellij;
 
 import com.intellij.ide.DataManager;
 import com.intellij.openapi.actionSystem.*;
@@ -12,8 +12,8 @@ import com.intellij.psi.PsiFile;
 import com.intellij.ui.DoubleClickListener;
 import com.intellij.ui.PopupHandler;
 import com.intellij.ui.treeStructure.Tree;
+import io.openliberty.tools.intellij.util.*;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.*;
 
 import javax.swing.*;
 import javax.swing.event.TreeSelectionEvent;
@@ -38,7 +38,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
         // create ActionToolBar
         final ActionManager actionManager = ActionManager.getInstance();
         DefaultActionGroup actionGroup = new DefaultActionGroup("DefaultActionGroup", false);
-        actionGroup.add(ActionManager.getInstance().getAction("org.liberty.intellij.actions.RefreshLibertyToolbar"));
+        actionGroup.add(ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.RefreshLibertyToolbar"));
         ActionToolbar actionToolbar = actionManager.createActionToolbar(ActionPlaces.UNKNOWN, actionGroup, true);
         actionToolbar.setOrientation(SwingConstants.HORIZONTAL);
         this.setToolbar(actionToolbar.getComponent());
@@ -156,27 +156,27 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                         LibertyProjectNode libertyNode = ((LibertyProjectNode) node);
                         final DefaultActionGroup group = new DefaultActionGroup();
                         if (libertyNode.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-                            AnAction viewEffectivePom = ActionManager.getInstance().getAction("org.liberty.intellij.actions.ViewEffectivePom");
+                            AnAction viewEffectivePom = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewEffectivePom");
                             group.add(viewEffectivePom);
-                            AnAction viewIntegrationReport = ActionManager.getInstance().getAction("org.liberty.intellij.actions.ViewIntegrationTestReport");
+                            AnAction viewIntegrationReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewIntegrationTestReport");
                             group.add(viewIntegrationReport);
-                            AnAction viewUnitTestReport = ActionManager.getInstance().getAction("org.liberty.intellij.actions.ViewUnitTestReport");
+                            AnAction viewUnitTestReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewUnitTestReport");
                             group.add(viewUnitTestReport);
                             group.addSeparator();
                         } else if (libertyNode.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-                            AnAction viewGradleConfig = ActionManager.getInstance().getAction("org.liberty.intellij.actions.ViewGradleConfig");
+                            AnAction viewGradleConfig = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewGradleConfig");
                             group.add(viewGradleConfig);
-                            AnAction viewTestReport = ActionManager.getInstance().getAction("org.liberty.intellij.actions.ViewTestReport");
+                            AnAction viewTestReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewTestReport");
                             group.add(viewTestReport);
                             group.addSeparator();
                         }
-                        AnAction startAction = ActionManager.getInstance().getAction("org.liberty.intellij.actions.LibertyDevStartAction");
+                        AnAction startAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevStartAction");
                         group.add(startAction);
-                        AnAction customStartAction = ActionManager.getInstance().getAction("org.liberty.intellij.actions.LibertyDevCustomStartAction");
+                        AnAction customStartAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevCustomStartAction");
                         group.add(customStartAction);
-                        AnAction stopAction = ActionManager.getInstance().getAction("org.liberty.intellij.actions.LibertyDevStopAction");
+                        AnAction stopAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevStopAction");
                         group.add(stopAction);
-                        AnAction runTestsAction = ActionManager.getInstance().getAction("org.liberty.intellij.actions.LibertyDevRunTestsAction");
+                        AnAction runTestsAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevRunTestsAction");
                         group.add(runTestsAction);
 
                         ActionPopupMenu menu = ActionManager.getInstance().createActionPopupMenu(ActionPlaces.UNKNOWN, group);
@@ -197,31 +197,31 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                     log.debug("Selected: " + actionNodeName);
                     if (actionNodeName.equals(Constants.LIBERTY_DEV_START)) {
                         // calls action on double click
-                        am.getAction("org.liberty.intellij.actions.LibertyDevStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("LibertyDevStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_CUSTOM_START)) {
-                        am.getAction("org.liberty.intellij.actions.LibertyDevCustomStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("LibertyDevCustomStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_STOP)) {
-                        am.getAction("org.liberty.intellij.actions.LibertyDevStopAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("LibertyDevStopAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_TESTS)) {
-                        am.getAction("org.liberty.intellij.actions.LibertyDevRunTestsAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("LibertyDevRunTestsAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.VIEW_INTEGRATION_TEST_REPORT)) {
-                        am.getAction("org.liberty.intellij.actions.ViewIntegrationTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("ViewIntegrationTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.VIEW_UNIT_TEST_REPORT)) {
-                        am.getAction("org.liberty.intellij.actions.ViewUnitTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("ViewUnitTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.VIEW_TEST_REPORT)) {
-                        am.getAction("org.liberty.intellij.actions.ViewTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction("ViewTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -116,7 +116,7 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_CUSTOM_START));
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_STOP));
             node.add(new LibertyActionNode(Constants.LIBERTY_DEV_TESTS));
-            node.add(new LibertyActionNode(Constants.VIEW_TEST_REPORT));
+            node.add(new LibertyActionNode(Constants.VIEW_GRADLE_TEST_REPORT));
         }
 
         Tree tree = new Tree(top);
@@ -156,27 +156,27 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                         LibertyProjectNode libertyNode = ((LibertyProjectNode) node);
                         final DefaultActionGroup group = new DefaultActionGroup();
                         if (libertyNode.getProjectType().equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-                            AnAction viewEffectivePom = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewEffectivePom");
+                            AnAction viewEffectivePom = ActionManager.getInstance().getAction(Constants.VIEW_EFFECTIVE_POM_ACTION_ID);
                             group.add(viewEffectivePom);
-                            AnAction viewIntegrationReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewIntegrationTestReport");
+                            AnAction viewIntegrationReport = ActionManager.getInstance().getAction(Constants.VIEW_INTEGRATION_TEST_REPORT_ACTION_ID);
                             group.add(viewIntegrationReport);
-                            AnAction viewUnitTestReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewUnitTestReport");
+                            AnAction viewUnitTestReport = ActionManager.getInstance().getAction(Constants.VIEW_UNIT_TEST_REPORT_ACTION_ID);
                             group.add(viewUnitTestReport);
                             group.addSeparator();
                         } else if (libertyNode.getProjectType().equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-                            AnAction viewGradleConfig = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewGradleConfig");
+                            AnAction viewGradleConfig = ActionManager.getInstance().getAction(Constants.VIEW_GRADLE_CONFIG_ACTION_ID);
                             group.add(viewGradleConfig);
-                            AnAction viewTestReport = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.ViewTestReport");
+                            AnAction viewTestReport = ActionManager.getInstance().getAction(Constants.VIEW_GRADLE_TEST_REPORT_ACTION_ID);
                             group.add(viewTestReport);
                             group.addSeparator();
                         }
-                        AnAction startAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevStartAction");
+                        AnAction startAction = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_START_ACTION_ID);
                         group.add(startAction);
-                        AnAction customStartAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevCustomStartAction");
+                        AnAction customStartAction = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_CUSTOM_START_ACTION_ID);
                         group.add(customStartAction);
-                        AnAction stopAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevStopAction");
+                        AnAction stopAction = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_STOP_ACTION_ID);
                         group.add(stopAction);
-                        AnAction runTestsAction = ActionManager.getInstance().getAction("io.openliberty.tools.intellij.actions.LibertyDevRunTestsAction");
+                        AnAction runTestsAction = ActionManager.getInstance().getAction(Constants.LIBERTY_DEV_TESTS_ACTION_ID);
                         group.add(runTestsAction);
 
                         ActionPopupMenu menu = ActionManager.getInstance().createActionPopupMenu(ActionPlaces.UNKNOWN, group);
@@ -197,31 +197,31 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
                     log.debug("Selected: " + actionNodeName);
                     if (actionNodeName.equals(Constants.LIBERTY_DEV_START)) {
                         // calls action on double click
-                        am.getAction("LibertyDevStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.LIBERTY_DEV_START_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_CUSTOM_START)) {
-                        am.getAction("LibertyDevCustomStartAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.LIBERTY_DEV_CUSTOM_START_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_STOP)) {
-                        am.getAction("LibertyDevStopAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.LIBERTY_DEV_STOP_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.LIBERTY_DEV_TESTS)) {
-                        am.getAction("LibertyDevRunTestsAction").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.LIBERTY_DEV_TESTS_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.VIEW_INTEGRATION_TEST_REPORT)) {
-                        am.getAction("ViewIntegrationTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.VIEW_INTEGRATION_TEST_REPORT_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     } else if (actionNodeName.equals(Constants.VIEW_UNIT_TEST_REPORT)) {
-                        am.getAction("ViewUnitTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                        am.getAction(Constants.VIEW_UNIT_TEST_REPORT_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
-                    } else if (actionNodeName.equals(Constants.VIEW_TEST_REPORT)) {
-                        am.getAction("ViewTestReport").actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
+                    } else if (actionNodeName.equals(Constants.VIEW_GRADLE_TEST_REPORT)) {
+                        am.getAction(Constants.VIEW_GRADLE_TEST_REPORT_ACTION_ID).actionPerformed(new AnActionEvent(null, DataManager.getInstance().getDataContext(),
                                 ActionPlaces.UNKNOWN, new Presentation(),
                                 ActionManager.getInstance(), 0));
                     }

--- a/src/main/java/io/openliberty/tools/intellij/LibertyProjectNode.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyProjectNode.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij;
+package io.openliberty.tools.intellij;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -1,15 +1,17 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
-import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.actionSystem.AnAction;
+import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import org.liberty.intellij.util.LibertyActionUtil;
-import org.liberty.intellij.util.LibertyProjectUtil;
-import org.liberty.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyActionUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
-public class LibertyDevStartAction extends AnAction {
+public class LibertyDevCustomStartAction extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -27,11 +29,21 @@ public class LibertyDevStartAction extends AnAction {
         final String projectName = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_NAME);
         final String projectType = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_TYPE);
 
-        String startCmd = null;
+        String msg;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev -f \"" + file.getCanonicalPath() + "\"";
+            msg = "Specify custom parameters for the liberty dev command (e.g. -DhotTests=true)";
+        } else {
+            msg = "Specify custom parameters for the liberty dev command (e.g. --hotTests)";
+        }
+        String customParams = Messages.showInputDialog(msg, "Liberty Dev Custom Parameters",  Messages.getQuestionIcon());
+
+
+        String startCmd = null;
+        if (customParams == null) { return; }
+        if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
+            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev " + customParams + " -f \"" + file.getCanonicalPath() + "\"";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDev -b=" + file.getCanonicalPath();
+            startCmd = "gradle libertyDev " + customParams + " -b=" + file.getCanonicalPath();
         }
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -1,16 +1,13 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyActionUtil;
-import org.liberty.intellij.util.LibertyProjectUtil;
-
-import java.io.IOException;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyActionUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 public class LibertyDevRunTestsAction extends AnAction {
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -1,17 +1,15 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
-import com.intellij.openapi.actionSystem.AnAction;
-import com.intellij.openapi.actionSystem.AnActionEvent;
+import com.intellij.openapi.actionSystem.*;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyActionUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyActionUtil;
-import org.liberty.intellij.util.LibertyProjectUtil;
 
-public class LibertyDevCustomStartAction extends AnAction {
+public class LibertyDevStartAction extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -29,21 +27,11 @@ public class LibertyDevCustomStartAction extends AnAction {
         final String projectName = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_NAME);
         final String projectType = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_TYPE);
 
-        String msg;
-        if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            msg = "Specify custom parameters for the liberty dev command (e.g. -DhotTests=true)";
-        } else {
-            msg = "Specify custom parameters for the liberty dev command (e.g. --hotTests)";
-        }
-        String customParams = Messages.showInputDialog(msg, "Liberty Dev Custom Parameters",  Messages.getQuestionIcon());
-
-
         String startCmd = null;
-        if (customParams == null) { return; }
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
-            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev " + customParams + " -f \"" + file.getCanonicalPath() + "\"";
+            startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev -f \"" + file.getCanonicalPath() + "\"";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {
-            startCmd = "gradle libertyDev " + customParams + " -b=" + file.getCanonicalPath();
+            startCmd = "gradle libertyDev -b=" + file.getCanonicalPath();
         }
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -1,16 +1,13 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.project.Project;
-import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.plugins.terminal.ShellTerminalWidget;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyActionUtil;
-import org.liberty.intellij.util.LibertyProjectUtil;
-
-import java.io.IOException;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyActionUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 public class LibertyDevStopAction extends AnAction {
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -8,9 +8,9 @@ import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.treeStructure.Tree;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.LibertyExplorer;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.LibertyExplorer;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 import javax.swing.*;
 import java.awt.*;

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -7,8 +7,8 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 public class ViewEffectivePom extends AnAction {
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
@@ -7,8 +7,8 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 public class ViewGradleConfig extends AnAction {
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -8,13 +8,13 @@ import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 
 import java.io.File;
 import java.nio.file.Paths;
 
-public class ViewUnitTestReport extends AnAction {
+public class ViewIntegrationTestReport extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -31,17 +31,18 @@ public class ViewUnitTestReport extends AnAction {
 
         // get path to project folder
         final VirtualFile parentFile = file.getParent();
-        File surefireReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "surefire-report.html").normalize().toAbsolutePath().toFile();
-        VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
+        File failsafeReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "failsafe-report.html").normalize().toAbsolutePath().toFile();
+        VirtualFile failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
 
-        if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
-            Messages.showErrorDialog(project, "Test report (" + surefireReportFile.getAbsolutePath() + ") does not exist.  " +
+
+        if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
+            Messages.showErrorDialog(project, "Test report (" + failsafeReportFile.getAbsolutePath() + ") does not exist.  " +
                             "Run tests to generate a test report.  Ensure your test report is generating at the correct location.",
-                    "Unit Test Report Does Not Exist");
+                    "Integration Test Report Does Not Exist");
             return;
         }
 
         // open test report in browser
-        BrowserUtil.browse(surefireReportVirtualFile.getUrl());
+        BrowserUtil.browse(failsafeReportVirtualFile.getUrl());
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -7,10 +7,10 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.util.Constants;
+import io.openliberty.tools.intellij.util.LibertyGradleUtil;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyGradleUtil;
-import org.liberty.intellij.util.LibertyProjectUtil;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.actions;
+package io.openliberty.tools.intellij.actions;
 
 import com.intellij.ide.BrowserUtil;
 import com.intellij.openapi.actionSystem.AnAction;
@@ -7,15 +7,14 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import org.jetbrains.annotations.NotNull;
-import org.liberty.intellij.util.Constants;
-import org.liberty.intellij.util.LibertyProjectUtil;
+import io.openliberty.tools.intellij.util.Constants;
 
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
 
-public class ViewIntegrationTestReport extends AnAction {
+public class ViewUnitTestReport extends AnAction {
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -32,18 +31,17 @@ public class ViewIntegrationTestReport extends AnAction {
 
         // get path to project folder
         final VirtualFile parentFile = file.getParent();
-        File failsafeReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "failsafe-report.html").normalize().toAbsolutePath().toFile();
-        VirtualFile failsafeReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(failsafeReportFile);
+        File surefireReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "surefire-report.html").normalize().toAbsolutePath().toFile();
+        VirtualFile surefireReportVirtualFile = LocalFileSystem.getInstance().findFileByIoFile(surefireReportFile);
 
-
-        if (failsafeReportVirtualFile == null || !failsafeReportVirtualFile.exists()) {
-            Messages.showErrorDialog(project, "Test report (" + failsafeReportFile.getAbsolutePath() + ") does not exist.  " +
+        if (surefireReportVirtualFile == null || !surefireReportVirtualFile.exists()) {
+            Messages.showErrorDialog(project, "Test report (" + surefireReportFile.getAbsolutePath() + ") does not exist.  " +
                             "Run tests to generate a test report.  Ensure your test report is generating at the correct location.",
-                    "Integration Test Report Does Not Exist");
+                    "Unit Test Report Does Not Exist");
             return;
         }
 
         // open test report in browser
-        BrowserUtil.browse(failsafeReportVirtualFile.getUrl());
+        BrowserUtil.browse(surefireReportVirtualFile.getUrl());
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 public final class Constants {
     public static final String LIBERTY_DEV_DASHBOARD_ID = "Liberty Dev Dashboard";

--- a/src/main/java/io/openliberty/tools/intellij/util/Constants.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/Constants.java
@@ -15,7 +15,7 @@ public final class Constants {
     public static final String VIEW_UNIT_TEST_REPORT = "View unit test report";
 
     // Gradle
-    public static final String VIEW_TEST_REPORT = "View test report";
+    public static final String VIEW_GRADLE_TEST_REPORT = "View test report";
     public static final String TEST_REPORT_STRING = "Test Summary";
 
     public static final String LIBERTY_TREE = "LibertyTree";
@@ -25,4 +25,17 @@ public final class Constants {
     public static final String LIBERTY_BUILD_FILE = "LIBERTY_BUILD_FILE";
     public static final String LIBERTY_PROJECT_NAME = "LIBERTY_PROJECT_NAME";
     public static final String LIBERTY_PROJECT_TYPE = "LIBERTY_PROJECT_TYPE";
+
+    /**
+     * Constants for Action IDs
+     */
+    public static final String LIBERTY_DEV_START_ACTION_ID = "io.openliberty.tools.intellij.actions.LibertyDevStartAction";
+    public static final String LIBERTY_DEV_CUSTOM_START_ACTION_ID = "io.openliberty.tools.intellij.actions.LibertyDevCustomStartAction";
+    public static final String LIBERTY_DEV_STOP_ACTION_ID = "io.openliberty.tools.intellij.actions.LibertyDevStopAction";
+    public static final String LIBERTY_DEV_TESTS_ACTION_ID = "io.openliberty.tools.intellij.actions.LibertyDevRunTestsAction";
+    public static final String VIEW_INTEGRATION_TEST_REPORT_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewIntegrationTestReport";
+    public static final String VIEW_UNIT_TEST_REPORT_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewUnitTestReport";
+    public static final String VIEW_GRADLE_TEST_REPORT_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewTestReport";
+    public static final String VIEW_GRADLE_CONFIG_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewGradleConfig";
+    public static final String VIEW_EFFECTIVE_POM_ACTION_ID = "io.openliberty.tools.intellij.actions.ViewEffectivePom";
 }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.jediterm.terminal.TtyConnector;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyGradleUtil.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.vfs.VirtualFile;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyMavenUtil.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.actionSystem.CommonDataKeys;
 import com.intellij.openapi.actionSystem.DataContext;

--- a/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
@@ -1,4 +1,4 @@
-package org.liberty.intellij.util;
+package io.openliberty.tools.intellij.util;
 
 import com.intellij.openapi.actionSystem.DataProvider;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -31,6 +31,5 @@ public class TreeDataProvider implements DataProvider {
         this.projectName = projectName;
         this.projectType = projectType;
     }
-
 
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,49 +14,49 @@
 
     <extensions defaultExtensionNs="com.intellij">
         <toolWindow anchor="right" id="Liberty Dev Dashboard" icon="/icons/OL_logo_13.svg"
-                    factoryClass="org.liberty.intellij.LibertyDevToolWindowFactory"/>
+                    factoryClass="io.openliberty.tools.intellij.LibertyDevToolWindowFactory"/>
     </extensions>
 
 
     <actions>
-        <action id="org.liberty.intellij.actions.LibertyDevStartAction"
-                class="org.liberty.intellij.actions.LibertyDevStartAction" text="Start"
+        <action id="io.openliberty.tools.intellij.actions.LibertyDevStartAction"
+                class="io.openliberty.tools.intellij.actions.LibertyDevStartAction" text="Start"
                 description="Start Liberty Dev on current build file" icon="AllIcons.General.GearPlain" />
 
-        <action id="org.liberty.intellij.actions.LibertyDevCustomStartAction"
-                class="org.liberty.intellij.actions.LibertyDevCustomStartAction" text="Start..."
+        <action id="io.openliberty.tools.intellij.actions.LibertyDevCustomStartAction"
+                class="io.openliberty.tools.intellij.actions.LibertyDevCustomStartAction" text="Start..."
                 description="Custom Start Liberty Dev on current build file" icon="AllIcons.General.GearPlain" />
 
-        <action id="org.liberty.intellij.actions.LibertyDevStopAction"
-                class="org.liberty.intellij.actions.LibertyDevStopAction" text="Stop"
+        <action id="io.openliberty.tools.intellij.actions.LibertyDevStopAction"
+                class="io.openliberty.tools.intellij.actions.LibertyDevStopAction" text="Stop"
                 description="Stop Liberty Dev on current build file" icon="AllIcons.General.GearPlain" />
 
-        <action id="org.liberty.intellij.actions.LibertyDevRunTestsAction"
-                class="org.liberty.intellij.actions.LibertyDevRunTestsAction" text="Run Tests"
+        <action id="io.openliberty.tools.intellij.actions.LibertyDevRunTestsAction"
+                class="io.openliberty.tools.intellij.actions.LibertyDevRunTestsAction" text="Run Tests"
                 description="Run tests on current build file" icon="AllIcons.General.GearPlain" />
 
-        <action id="org.liberty.intellij.actions.ViewIntegrationTestReport"
-                class="org.liberty.intellij.actions.ViewIntegrationTestReport" text="View integration test report"
+        <action id="io.openliberty.tools.intellij.actions.ViewIntegrationTestReport"
+                class="io.openliberty.tools.intellij.actions.ViewIntegrationTestReport" text="View integration test report"
                 description="Open the Maven Failsafe test report" icon="AllIcons.General.Web" />
 
-        <action id="org.liberty.intellij.actions.ViewUnitTestReport"
-                class="org.liberty.intellij.actions.ViewUnitTestReport" text="View unit test report"
+        <action id="io.openliberty.tools.intellij.actions.ViewUnitTestReport"
+                class="io.openliberty.tools.intellij.actions.ViewUnitTestReport" text="View unit test report"
                 description="Open the Maven Surefire test report" icon="AllIcons.General.Web" />
 
-        <action id="org.liberty.intellij.actions.ViewTestReport"
-                class="org.liberty.intellij.actions.ViewTestReport" text="View test report"
+        <action id="io.openliberty.tools.intellij.actions.ViewTestReport"
+                class="io.openliberty.tools.intellij.actions.ViewTestReport" text="View test report"
                 description="Open the Gradle test report" icon="AllIcons.General.Web" />
 
-        <action id="org.liberty.intellij.actions.ViewEffectivePom"
-                class="org.liberty.intellij.actions.ViewEffectivePom" text="View Effective POM"
+        <action id="io.openliberty.tools.intellij.actions.ViewEffectivePom"
+                class="io.openliberty.tools.intellij.actions.ViewEffectivePom" text="View Effective POM"
                 description="Open the pom.xml" icon="AllIcons.FileTypes.Config" />
 
-        <action id="org.liberty.intellij.actions.ViewGradleConfig"
-                class="org.liberty.intellij.actions.ViewGradleConfig" text="View Gradle Config"
+        <action id="io.openliberty.tools.intellij.actions.ViewGradleConfig"
+                class="io.openliberty.tools.intellij.actions.ViewGradleConfig" text="View Gradle Config"
                 description="Open the build.gradle" icon="AllIcons.FileTypes.Config" />
 
-        <action id="org.liberty.intellij.actions.RefreshLibertyToolbar"
-                class="org.liberty.intellij.actions.RefreshLibertyToolbar" text="Refresh Liberty Dev Dashboard"
+        <action id="io.openliberty.tools.intellij.actions.RefreshLibertyToolbar"
+                class="io.openliberty.tools.intellij.actions.RefreshLibertyToolbar" text="Refresh Liberty Dev Dashboard"
                 description="Refresh Liberty Dev Dashboard projects" icon="AllIcons.Actions.Refresh"/>
     </actions>
 </idea-plugin>


### PR DESCRIPTION
Fix for #2 
- updated groupId to `io.openliberty.tools`
- refactored package name to `io.openliberty.tools.intellij`
- modified `testCompile` to [`testImplementation`](https://github.com/OpenLiberty/open-liberty-tools-intellij/compare/master...kathrynkodama:dev?expand=1#diff-c197962302397baf3a4cc36463dce5eaR16) to resolve the following warning `The testCompile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the testImplementation configuration instead.`


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>