### PR TITLE
fix for terminal init

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -1,6 +1,7 @@
 package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.*;
+import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import io.openliberty.tools.intellij.util.Constants;
@@ -18,6 +19,8 @@ public class LibertyDevStartAction extends AnAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
+        Logger log = Logger.getInstance(LibertyDevStartAction.class);;
+
         final Project project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) return;
 
@@ -35,7 +38,11 @@ public class LibertyDevStartAction extends AnAction {
         }
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
-        if (widget == null) return;
-        LibertyActionUtil.executeCommand(widget, startCmd);
+        if (widget == null) {
+            log.debug("Could not get or create terminal widget for the given project");
+            return;
+        } else {
+            LibertyActionUtil.executeCommand(widget, startCmd);
+        }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -39,7 +39,7 @@ public class LibertyDevStartAction extends AnAction {
 
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
         if (widget == null) {
-            log.debug("Could not get or create terminal widget for the given project");
+            log.debug("Could not get or create terminal widget for " + projectName);
             return;
         } else {
             LibertyActionUtil.executeCommand(widget, startCmd);

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyActionUtil.java
@@ -12,17 +12,24 @@ public class LibertyActionUtil {
 
     /**
      * Send the given command to the given ShellTerminalWidget
+     *
      * @param widget
      * @param cmd
      */
     public static void executeCommand(ShellTerminalWidget widget, String cmd) {
-        Logger log = Logger.getInstance(LibertyActionUtil.class);;
-        widget.grabFocus();
-        TtyConnector connector = widget.getTtyConnector();
-        String enterCode = new String(widget.getTerminalStarter().getCode(KeyEvent.VK_ENTER, 0), StandardCharsets.UTF_8);
-        StringBuilder result = new StringBuilder();
-        result.append(cmd).append(enterCode);
+        Logger log = Logger.getInstance(LibertyActionUtil.class);
         try {
+            widget.grabFocus();
+            TtyConnector connector = widget.getTtyConnector();
+            if (connector == null) {
+                // new terminal, use build in execute command function
+                widget.executeCommand(cmd);
+                return;
+            }
+            // existing terminal, add a new line character and send command through connector
+            String enterCode = new String(widget.getTerminalStarter().getCode(KeyEvent.VK_ENTER, 0), StandardCharsets.UTF_8);
+            StringBuilder result = new StringBuilder();
+            result.append(cmd).append(enterCode);
             connector.write(result.toString());
         } catch (IOException ex) {
             log.error(ex.getMessage());


### PR DESCRIPTION
Fix for #10 

Use the built in [`ShellTerminalWidget.executeCommand`](https://github.com/JetBrains/intellij-community/blob/master/plugins/terminal/src/org/jetbrains/plugins/terminal/ShellTerminalWidget.java#L121) function for new terminal sessions. 

For terminal sessions that already exist, use the [widget connector](https://gitlab.com/zipizap/jediterm/blob/master/src-terminal/com/jediterm/terminal/TtyConnector.java#L20) to send a new line character followed by the command.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>