### PR TITLE
fix for refresh button

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -264,7 +264,6 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
 
         tree.setCellRenderer(newRenderer);
 
-        treeDataProvider.setTreeOnRefresh(tree);
         return tree;
     }
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ExecuteLibertyDevTask.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ExecuteLibertyDevTask.java
@@ -26,11 +26,6 @@ import java.util.HashMap;
 public class ExecuteLibertyDevTask extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ExecuteLibertyDevTask.class);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -16,11 +16,6 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 public class LibertyDevCustomStartAction extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(LibertyDevCustomStartAction.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -17,11 +17,6 @@ import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 public class LibertyDevRunTestsAction extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(LibertyDevRunTestsAction.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -13,11 +13,6 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 public class LibertyDevStartAction extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(LibertyDevStartAction.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -17,11 +17,6 @@ import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 public class LibertyDevStopAction extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(LibertyDevStopAction.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
@@ -6,7 +6,6 @@ import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.ui.treeStructure.actions.CollapseAllAction;
 import com.intellij.ui.treeStructure.actions.ExpandAllAction;
-import io.openliberty.tools.intellij.util.Constants;
 
 public class LibertyToolbarActionGroup extends DefaultActionGroup {
 
@@ -31,20 +30,7 @@ public class LibertyToolbarActionGroup extends DefaultActionGroup {
 
     @Override
     public void update(AnActionEvent event) {
-        // Enable/disable depending on whether user is editing...
-        Tree updatedTree = (Tree) event.getDataContext().getData(Constants.LIBERTY_DASHBOARD_TREE);
-
-        if (updatedTree != null && updatedTree != this.tree) {
-            remove(this.collapseAction);
-            remove(this.expandAction);
-            CollapseAllAction newCollapseAction = new CollapseAllAction(updatedTree);
-            ExpandAllAction newExpandAction = new ExpandAllAction(updatedTree);
-            add(newCollapseAction);
-            add(newExpandAction);
-            this.collapseAction = newCollapseAction;
-            this.expandAction = newExpandAction;
-            this.tree = updatedTree;
-        }
+        super.update(event);
     }
 
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
@@ -1,7 +1,6 @@
 package io.openliberty.tools.intellij.actions;
 
 import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
 import com.intellij.ui.treeStructure.Tree;
 import com.intellij.ui.treeStructure.actions.CollapseAllAction;
@@ -27,10 +26,4 @@ public class LibertyToolbarActionGroup extends DefaultActionGroup {
         add(this.collapseAction);
         add(this.expandAction);
     }
-
-    @Override
-    public void update(AnActionEvent event) {
-        super.update(event);
-    }
-
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -22,11 +22,6 @@ import java.awt.*;
 public class RefreshLibertyToolbar extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(RefreshLibertyToolbar.class);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -1,12 +1,12 @@
 package io.openliberty.tools.intellij.actions;
 
-import com.intellij.ide.DataManager;
 import com.intellij.ide.projectView.ProjectView;
 import com.intellij.openapi.actionSystem.ActionToolbar;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
 import com.intellij.ui.content.Content;
@@ -14,7 +14,6 @@ import com.intellij.ui.treeStructure.Tree;
 import io.openliberty.tools.intellij.LibertyExplorer;
 import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyProjectUtil;
-import io.openliberty.tools.intellij.util.TreeDataProvider;
 import org.jetbrains.annotations.NotNull;
 
 import javax.swing.*;
@@ -43,6 +42,8 @@ public class RefreshLibertyToolbar extends AnAction {
 
         Content content = libertyDevToolWindow.getContentManager().findContent("Projects");
 
+        SimpleToolWindowPanel simpleToolWindowPanel = (SimpleToolWindowPanel) content.getComponent();
+
         JComponent libertyWindow = content.getComponent();
 
         Component[] components = libertyWindow.getComponents();
@@ -60,18 +61,15 @@ public class RefreshLibertyToolbar extends AnAction {
 
         if (existingTree != null && existingActionToolbar != null) {
             Tree tree = LibertyExplorer.buildTree(project, content.getComponent().getBackground());
+            ActionToolbar actionToolbar = LibertyExplorer.buildActionToolbar(tree);
 
-            ActionToolbar actionToolbar = (ActionToolbar) existingActionToolbar;
+            simpleToolWindowPanel.remove(existingActionToolbar);
+            simpleToolWindowPanel.remove(existingTree);
 
-            libertyWindow.remove(existingTree);
-            libertyWindow.add(tree, BorderLayout.CENTER);
-            libertyWindow.revalidate();
-            libertyWindow.repaint();
-
-            TreeDataProvider treeDataProvider = (TreeDataProvider) DataManager.getDataProvider(tree);
-            treeDataProvider.setTreeOnRefresh(tree);
-            actionToolbar.updateActionsImmediately();
-            actionToolbar.setShowSeparatorTitles(true);
+            simpleToolWindowPanel.setToolbar(actionToolbar.getComponent());
+            simpleToolWindowPanel.setContent(tree);
+            simpleToolWindowPanel.revalidate();
+            simpleToolWindowPanel.repaint();
         }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
@@ -14,11 +14,6 @@ import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 public class ViewEffectivePom extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ViewEffectivePom.class);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
@@ -14,11 +14,6 @@ import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 public class ViewGradleConfig extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ViewGradleConfig.class);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -21,11 +21,6 @@ import java.nio.file.Paths;
 public class ViewIntegrationTestReport extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ViewIntegrationTestReport.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -31,11 +31,6 @@ import java.util.stream.Stream;
 public class ViewTestReport extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ViewTestReport.class);;
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -21,11 +21,6 @@ import java.nio.file.Paths;
 public class ViewUnitTestReport extends AnAction {
 
     @Override
-    public void update(@NotNull AnActionEvent e) {
-        super.update(e);
-    }
-
-    @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
         Logger log = Logger.getInstance(ViewUnitTestReport.class);;
         final Project project = LibertyProjectUtil.getProject(e.getDataContext());

--- a/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/TreeDataProvider.java
@@ -15,7 +15,6 @@ public class TreeDataProvider implements DataProvider {
     public String projectName;
     public String projectType;
     public HashMap<String, ArrayList<Object>> map = new HashMap<String, ArrayList<Object>>();
-    public Tree tree;
 
     @Nullable
     @Override
@@ -28,8 +27,6 @@ public class TreeDataProvider implements DataProvider {
             return this.projectType;
         } else if (dataId.equals(Constants.LIBERTY_PROJECT_MAP)) {
             return this.map;
-        } else if (dataId.equals(Constants.LIBERTY_DASHBOARD_TREE)) {
-            return this.tree;
         }
         return null;
     }
@@ -43,9 +40,4 @@ public class TreeDataProvider implements DataProvider {
     public void setProjectMap(@NotNull HashMap<String, ArrayList<Object>> map) {
         this.map = map;
     }
-
-    public void setTreeOnRefresh(@NotNull Tree tree) {
-        this.tree = tree;
-    }
-
 }


### PR DESCRIPTION
Fix for #17 

Redraw the actionToolbar component and the tree component upon hitting refresh.  Now when the user selects refresh, the collapse/expand all options in the toolbar react right away (previously you had to select a tree node in order for them to register the new tree view), and the line separating the toolbar and the tree view is maintained (previously it would occasionally disappear upon hitting refresh).

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>