### PR TITLE
added text for when tree is null, improved error handling

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RefreshLibertyToolbar.java
@@ -9,6 +9,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.SimpleToolWindowPanel;
 import com.intellij.openapi.wm.ToolWindow;
 import com.intellij.openapi.wm.ToolWindowManager;
+import com.intellij.ui.components.JBTextArea;
 import com.intellij.ui.content.Content;
 import com.intellij.ui.treeStructure.Tree;
 import io.openliberty.tools.intellij.LibertyExplorer;
@@ -54,15 +55,24 @@ public class RefreshLibertyToolbar extends AnAction {
             }
         }
 
-        if (existingTree != null && existingActionToolbar != null) {
+        if (existingActionToolbar != null) {
             Tree tree = LibertyExplorer.buildTree(project, content.getComponent().getBackground());
             ActionToolbar actionToolbar = LibertyExplorer.buildActionToolbar(tree);
-
             simpleToolWindowPanel.remove(existingActionToolbar);
-            simpleToolWindowPanel.remove(existingTree);
 
+            if (existingTree != null) {
+                simpleToolWindowPanel.remove(existingTree);
+            }
             simpleToolWindowPanel.setToolbar(actionToolbar.getComponent());
-            simpleToolWindowPanel.setContent(tree);
+            if (tree != null) {
+                simpleToolWindowPanel.setContent(tree);
+            } else {
+                JBTextArea jbTextArea = new JBTextArea("No Liberty Maven or Liberty Gradle projects detected in this workspace.");
+                jbTextArea.setEditable(false);
+                jbTextArea.setBackground(simpleToolWindowPanel.getBackground());
+                jbTextArea.setLineWrap(true);
+                simpleToolWindowPanel.setContent(jbTextArea);
+            }
             simpleToolWindowPanel.revalidate();
             simpleToolWindowPanel.repaint();
         }

--- a/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
+++ b/src/main/java/io/openliberty/tools/intellij/util/LibertyProjectUtil.java
@@ -13,7 +13,10 @@ import com.intellij.terminal.JBTerminalWidget;
 import com.intellij.ui.content.Content;
 import com.sun.istack.Nullable;
 import org.jetbrains.plugins.terminal.*;
+import org.xml.sax.SAXException;
 
+import javax.xml.parsers.ParserConfigurationException;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Objects;
 
@@ -30,7 +33,7 @@ public class LibertyProjectUtil {
      * @param project
      * @return ArrayList of PsiFiles
      */
-    public static ArrayList<PsiFile> getGradleBuildFiles(Project project) {
+    public static ArrayList<PsiFile> getGradleBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
         return getBuildFiles(project, Constants.LIBERTY_GRADLE_PROJECT);
     }
 
@@ -39,7 +42,7 @@ public class LibertyProjectUtil {
      * @param project
      * @return ArrayList of PsiFiles
      */
-    public static ArrayList<PsiFile> getMavenBuildFiles(Project project) {
+    public static ArrayList<PsiFile> getMavenBuildFiles(Project project) throws IOException, SAXException, ParserConfigurationException {
         return getBuildFiles(project, Constants.LIBERTY_MAVEN_PROJECT);
     }
 
@@ -72,18 +75,14 @@ public class LibertyProjectUtil {
     }
 
     // returns valid build files for the current project
-    private static ArrayList<PsiFile> getBuildFiles(Project project, String buildFileType) {
+    private static ArrayList<PsiFile> getBuildFiles(Project project, String buildFileType) throws ParserConfigurationException, SAXException, IOException {
         ArrayList<PsiFile> buildFiles = new ArrayList<PsiFile>();
 
         if (buildFileType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
             PsiFile[] mavenFiles = FilenameIndex.getFilesByName(project, "pom.xml", GlobalSearchScope.projectScope(project));
             for (int i = 0; i < mavenFiles.length; i++) {
-                try {
-                    if (LibertyMavenUtil.validPom(mavenFiles[i])) {
-                        buildFiles.add(mavenFiles[i]);
-                    }
-                } catch (Exception e) {
-                    log.error("Error parsing pom.xml", e.getMessage());
+                if (LibertyMavenUtil.validPom(mavenFiles[i])) {
+                    buildFiles.add(mavenFiles[i]);
                 }
             }
         } else if (buildFileType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {


### PR DESCRIPTION
- added text when tree is null
<img width="592" alt="Screen Shot 2020-08-05 at 10 22 20 AM" src="https://user-images.githubusercontent.com/26146482/89425391-f0ec1200-d706-11ea-937e-f6364f7e54bf.png">

- improved error handling when plugin cannot read build files

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>