### PR TITLE
Display warning message if runs Liberty action from main Actions menu

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevCustomStartAction.java
@@ -10,10 +10,12 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevCustomStartAction extends LibertyGeneralAction {
 
+    public LibertyDevCustomStartAction() {
+        setActionCmd("start Liberty dev mode with custom parameters");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("start Liberty dev mode with custom parameters");
-
         String msg;
         String initialVal;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevRunTestsAction.java
@@ -11,9 +11,12 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevRunTestsAction extends LibertyGeneralAction {
 
+    public LibertyDevRunTestsAction() {
+        setActionCmd("run tests with Liberty dev mode");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("run tests with Liberty dev mode");
         String runTestsCommand = " ";
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, false);
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartAction.java
@@ -7,11 +7,15 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStartAction extends LibertyGeneralAction {
 
+    public LibertyDevStartAction() {
+        setActionCmd("start Liberty dev mode");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("start Liberty dev mode");
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, true);
         String startCmd = null;
+
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
             startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:dev -f \"" + buildFile.getCanonicalPath() + "\"";
         } else if (projectType.equals(Constants.LIBERTY_GRADLE_PROJECT)) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStartContainerAction.java
@@ -7,9 +7,12 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStartContainerAction extends LibertyGeneralAction {
 
+    public LibertyDevStartContainerAction() {
+        setActionCmd("start Liberty dev mode in a container");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("start Liberty dev mode in a container");
         String startCmd = null;
         if (projectType.equals(Constants.LIBERTY_MAVEN_PROJECT)) {
             startCmd = "mvn io.openliberty.tools:liberty-maven-plugin:devc -f \"" + buildFile.getCanonicalPath() + "\"";

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyDevStopAction.java
@@ -11,9 +11,12 @@ import org.jetbrains.plugins.terminal.ShellTerminalWidget;
 
 public class LibertyDevStopAction extends LibertyGeneralAction {
 
+    public LibertyDevStopAction() {
+        setActionCmd("stop Liberty dev mode");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("stop Liberty dev mode");
         ShellTerminalWidget widget = LibertyProjectUtil.getTerminalWidget(project, projectName, false);
         String stopCmd = "q";
         if (widget == null) {

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -27,7 +27,7 @@ public class LibertyGeneralAction extends AnAction {
     public void actionPerformed(@NotNull AnActionEvent e) {
         project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) {
-            String msg = "Unable to " + actionCmd + ", could not resolve project. Ensure you run the Liberty action from the Liberty tool window";
+            String msg = "Unable to " + actionCmd + ": Could not resolve project. Ensure you run the Liberty action from the Liberty tool window";
             notifyError(msg);
             log.debug(msg);
             return;
@@ -35,7 +35,7 @@ public class LibertyGeneralAction extends AnAction {
 
         buildFile = (VirtualFile) e.getDataContext().getData(Constants.LIBERTY_BUILD_FILE);
         if (buildFile == null) {
-            String msg = "Unable to " + actionCmd + ", could not resolve configuration file for  " + project.getName() + ". Ensure you run the Liberty action from the Liberty tool window";
+            String msg = "Unable to " + actionCmd + ": Could not resolve configuration file for  " + project.getName() + ". Ensure you run the Liberty action from the Liberty tool window";
             notifyError(msg);
             log.debug(msg);
             return;

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyGeneralAction.java
@@ -1,10 +1,15 @@
 package io.openliberty.tools.intellij.actions;
 
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationListener;
+import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
+import io.openliberty.tools.intellij.LibertyPluginIcons;
 import io.openliberty.tools.intellij.util.Constants;
 import io.openliberty.tools.intellij.util.LibertyProjectUtil;
 import org.jetbrains.annotations.NotNull;
@@ -22,19 +27,22 @@ public class LibertyGeneralAction extends AnAction {
     public void actionPerformed(@NotNull AnActionEvent e) {
         project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) {
-            log.debug("Unable to " + actionCmd + ", could not resolve project");
+            String msg = "Unable to " + actionCmd + ", could not resolve project. Ensure you run the Liberty action from the Liberty tool window";
+            notifyError(msg);
+            log.debug(msg);
             return;
         }
 
         buildFile = (VirtualFile) e.getDataContext().getData(Constants.LIBERTY_BUILD_FILE);
         if (buildFile == null) {
-            log.debug("Unable to " + actionCmd + ", could not resolve configuration file for  " + project.getName());
+            String msg = "Unable to " + actionCmd + ", could not resolve configuration file for  " + project.getName() + ". Ensure you run the Liberty action from the Liberty tool window";
+            notifyError(msg);
+            log.debug(msg);
             return;
         }
 
         projectName = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_NAME);
         projectType = (String) e.getDataContext().getData(Constants.LIBERTY_PROJECT_TYPE);
-
         executeLibertyAction();
     }
 
@@ -46,5 +54,15 @@ public class LibertyGeneralAction extends AnAction {
         // must be implemented by individual actions
     }
 
+    protected void notifyError(String errMsg) {
+        Notification notif = new Notification("Liberty"
+                , LibertyPluginIcons.libertyIcon
+                , "Liberty action was not able to start"
+                , ""
+                , errMsg
+                , NotificationType.WARNING
+                , NotificationListener.URL_OPENING_LISTENER);
+        Notifications.Bus.notify(notif, project);
+    }
 
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewEffectivePom.java
@@ -5,9 +5,12 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 
 public class ViewEffectivePom extends LibertyGeneralAction {
 
+    public ViewEffectivePom() {
+        setActionCmd("view effective POM");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("view effective POM");
         // open build file
         FileEditorManager.getInstance(project).openTextEditor(new OpenFileDescriptor(project, buildFile), true);
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewGradleConfig.java
@@ -5,10 +5,12 @@ import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 
 public class ViewGradleConfig extends LibertyGeneralAction {
 
+    public ViewGradleConfig() {
+        setActionCmd("view Gradle configuration file");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("view Gradle configuration file");
-
         // open build file
         FileEditorManager.getInstance(project).openTextEditor(new OpenFileDescriptor(project, buildFile), true);
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewIntegrationTestReport.java
@@ -14,10 +14,12 @@ import java.nio.file.Paths;
 
 public class ViewIntegrationTestReport extends LibertyGeneralAction {
 
+    public ViewIntegrationTestReport() {
+        setActionCmd("view integration test report");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("view integration test report");
-
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();
         File failsafeReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "failsafe-report.html").normalize().toAbsolutePath().toFile();

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewTestReport.java
@@ -25,9 +25,12 @@ import java.util.stream.Stream;
 
 public class ViewTestReport extends LibertyGeneralAction {
 
+    public ViewTestReport() {
+        setActionCmd("view Gradle test report");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("view Gradle test report");
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();
 

--- a/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/ViewUnitTestReport.java
@@ -14,9 +14,12 @@ import java.nio.file.Paths;
 
 public class ViewUnitTestReport extends LibertyGeneralAction {
 
+    public ViewUnitTestReport() {
+        setActionCmd("view unit test report");
+    }
+
     @Override
     protected void executeLibertyAction() {
-        setActionCmd("view unit test report");
         // get path to project folder
         final VirtualFile parentFile = buildFile.getParent();
         File surefireReportFile = Paths.get(parentFile.getCanonicalPath(), "target", "site", "surefire-report.html").normalize().toAbsolutePath().toFile();


### PR DESCRIPTION
We do not currently support starting a Liberty action from anywhere other than the Liberty tool window as the plugin requires knowledge of the project context. Display a popup warning to users if they try to run Liberty actions from the main Action menu (accessible via Shift > Shift).
![image](https://user-images.githubusercontent.com/26146482/125350580-f09fc200-e32c-11eb-9871-4c974dc58578.png)

![image](https://user-images.githubusercontent.com/26146482/125350549-e087e280-e32c-11eb-898a-44c60ffd064a.png)


Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>