### PR TITLE
Add null check for tree view

### DIFF
--- a/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
+++ b/src/main/java/io/openliberty/tools/intellij/LibertyExplorer.java
@@ -53,7 +53,6 @@ public class LibertyExplorer extends SimpleToolWindowPanel {
 
             this.setContent(jbTextArea);
         }
-
         ActionToolbar actionToolbar = buildActionToolbar(tree);
         this.setToolbar(actionToolbar.getComponent());
     }

--- a/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/LibertyToolbarActionGroup.java
@@ -18,9 +18,11 @@ public class LibertyToolbarActionGroup extends DefaultActionGroup {
         add(actionManager.getAction("io.openliberty.tools.intellij.actions.RunLibertyDevTask"));
         addSeparator();
 
-        DefaultTreeExpander expander = new DefaultTreeExpander(tree);
-        CommonActionsManager commonActionsManager = CommonActionsManager.getInstance();
-        add(commonActionsManager.createCollapseAllAction(expander, tree));
-        add(commonActionsManager.createExpandAllAction(expander, tree));
+        if (tree != null) {
+            DefaultTreeExpander expander = new DefaultTreeExpander(tree);
+            CommonActionsManager commonActionsManager = CommonActionsManager.getInstance();
+            add(commonActionsManager.createCollapseAllAction(expander, tree));
+            add(commonActionsManager.createExpandAllAction(expander, tree));
+        }
     }
 }

--- a/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
+++ b/src/main/java/io/openliberty/tools/intellij/actions/RunLibertyDevTask.java
@@ -18,6 +18,7 @@ import java.awt.*;
 
 
 public class RunLibertyDevTask extends AnAction {
+    Logger log = Logger.getInstance(RunLibertyDevTask.class);
 
     @Override
     public void update(@NotNull AnActionEvent e) {
@@ -42,6 +43,8 @@ public class RunLibertyDevTask extends AnAction {
                             e.getPresentation().setEnabled(true);
                         }
                     }
+                } else {
+                    log.debug("Tree view not built, no valid projects to run Liberty dev actions on");
                 }
             }
         }
@@ -49,8 +52,6 @@ public class RunLibertyDevTask extends AnAction {
 
     @Override
     public void actionPerformed(@NotNull AnActionEvent e) {
-        Logger log = Logger.getInstance(RunLibertyDevTask.class);
-
         final Project project = LibertyProjectUtil.getProject(e.getDataContext());
         if (project == null) return;
 
@@ -83,7 +84,7 @@ public class RunLibertyDevTask extends AnAction {
                     }
                 }
             } else {
-                log.debug("Tree view not built, no valid projects to Run Liberty Dev actions on");
+                log.debug("Tree view not built, no valid projects to run Liberty dev actions on");
             }
         }
     }


### PR DESCRIPTION
Fixes #57 

Tree parameter is populated with the list of Open Liberty projects detected in the workspace and the dev mode actions able to run against these projects.  Only display the tree view actions in the toolbar (ie. expandAll and collapseAll) if the tree parameter is not null.

Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>